### PR TITLE
fixed problem operators return null (non-variablized effects and non-computable) in function execution

### DIFF
--- a/agents/ModularAgent.py
+++ b/agents/ModularAgent.py
@@ -177,14 +177,14 @@ class ModularAgent(BaseAgent):
                             state, rhs_list=rhs_list,
                             add_skill_info=add_skill_info)
 
-        explanation, skill_info = next(iter(explanations), (None, None))
-        if(explanation is not None):
-            response = explanation.to_response(state, self)
+        response = EMPTY_RESPONSE
+        for explanation, skill_info in explanations:
+            tmp_resp = explanation.to_response(state, self)
+            if tmp_resp['inputs']['value'] is None:
+                continue
+            response = tmp_resp
             if(add_skill_info):
                 response["skill_info"] = skill_info
-
-        else:
-            response = EMPTY_RESPONSE
 
         return response
 

--- a/planners/fo_planner.py
+++ b/planners/fo_planner.py
@@ -593,7 +593,7 @@ def apply_operators(ele, operators, knowledge_base,epsilon):
         pattern = effect[0][1]
         u_mapping = unify(pattern, ground(ele), {}) #Returns a mapping to name the values in the expression
         
-        if(u_mapping):
+        if(u_mapping is not None):
             condition_sub = [subst(u_mapping,x) for x in operator.conditions]
             value_map = next(knowledge_base.fc_query(condition_sub, max_depth=0, epsilon=epsilon))
             
@@ -651,7 +651,6 @@ class FoPlannerModule(BasePlanner):
             state.set_view("func_knowledge_base",knowledge_base)
         else:
             knowledge_base = state.get_view("func_knowledge_base")            
-        
 
         for attr,input_val in sai.inputs.items():
             #Danny: This populates a list of explanations found earlier in How search that work"


### PR DESCRIPTION
Simple fix. Conditional checks if the mapping evaluates is True. Should check if it is not None. Unify returns None on failure. It also returns {} when it is successful, which evaluates to False. 